### PR TITLE
TEC-14892 - Update Export Options

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,8 @@ import Preview from "./Preview";
 
 import useDebounce from "./useDebounce";
 
+import { EXAMPLE_DATA } from "./data/example";
+
 import "./styles.css";
 
 const EXPORT_TYPE = {
@@ -21,7 +23,10 @@ function App() {
   const [rawContent, setRawContent] = useState(null);
   const debouncedContent = useDebounce(rawContent, 500);
   const [renderedContent, setRenderedContent] = useState(null);
-  const [editionData, setEditionData] = useState(null);
+  // const test = EXAMPLE_DATA.toString();
+
+  // const exampleData = JSON.parse(JSON.stringify(EXAMPLE_DATA));
+  const [editionData, setEditionData] = useState("");
   // const [masterFilename, setMasterFilename] = useState("template");
   const [campaignFilename, setCampaignFilename] = useState("template");
 
@@ -31,20 +36,20 @@ function App() {
       let html;
       try {
         vtl = Velocity.render(debouncedContent, editionData);
-        // console.log(html);
-        // console.log("VTL OK");
+        console.log(html);
+        console.log("VTL OK");
       } catch (error) {
-        // console.log("VTL ERROR");
-        // console.log(error);
+        console.log("VTL ERROR");
+        console.log(error);
       }
       try {
         html = mjml2html(vtl).html;
         setRenderedContent(html);
-        // console.log(html);
-        // console.log("MJML OK");
+        console.log(html);
+        console.log("MJML OK");
       } catch (error) {
-        // console.log("MJML ERROR");
-        // console.log(error);
+        console.log("MJML ERROR");
+        console.log(error);
         return;
       }
     }
@@ -52,14 +57,14 @@ function App() {
 
   const editorRef = useRef(null);
 
-  const onDataChange = (event) => {
+  const onDataChange = (data) => {
     try {
-      const raw = event.target.value;
+      const raw = data;
       const json = JSON.parse(raw);
       setEditionData(json);
     } catch (error) {
-      // console.log('DATA ERROR');
-      // console.log(error);
+      console.log('DATA ERROR');
+      console.log(error);
     }
   };
 
@@ -120,6 +125,17 @@ function App() {
   // const onMasterFilenameChange = (event) => setMasterFilename(event.target.value);
   const onCampaignFilenameChange = (event) => setCampaignFilename(event.target.value);
 
+  const handleUseExampleJSON = () => {
+    // const json = JSON.parse(JSON.stringify(EXAMPLE_DATA, null, 4));
+    const json = JSON.stringify(EXAMPLE_DATA, null, 4);
+    // const json = EXAMPLE_DATA;
+    console.log("before" + editionData);
+    document.getElementById("dataTextarea").value = json;
+    // setEditionData(json);
+    onDataChange(json);
+    console.log("after" + editionData);
+  }
+
   return (
     <>
       <div className="d-flex">
@@ -137,9 +153,11 @@ function App() {
           <Preview html={renderedContent} />
         </div>
       </div>
-
-      <div className="section-titles">Data</div>
-      <Data data={editionData} onChange={onDataChange} />
+      <div className="d-flex">
+        <div className="section-titles d-flex align-items-center">Data</div>
+        <button onClick={handleUseExampleJSON} className="m-0 p-0">Use Example JSON - 10/05/22</button>
+      </div>
+      <Data data={editionData} onChange={event => onDataChange(event.target.value)} />
       {/* Old Method which manually encodes the template, was used for when we didn't apply encoding on the backend */}
       {/* <Export
         filename={masterFilename}
@@ -151,7 +169,7 @@ function App() {
         filename={campaignFilename}
         onChange={onCampaignFilenameChange}
         onExport={() => onExport(campaignFilename, EXPORT_TYPE.CAMPAIGN)}
-        exportType={EXPORT_TYPE.NOT_ENCODED}
+        exportType="Template"
       />
     </>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,9 +23,6 @@ function App() {
   const [rawContent, setRawContent] = useState(null);
   const debouncedContent = useDebounce(rawContent, 500);
   const [renderedContent, setRenderedContent] = useState(null);
-  // const test = EXAMPLE_DATA.toString();
-
-  // const exampleData = JSON.parse(JSON.stringify(EXAMPLE_DATA));
   const [editionData, setEditionData] = useState("");
   // const [masterFilename, setMasterFilename] = useState("template");
   const [campaignFilename, setCampaignFilename] = useState("template");
@@ -36,20 +33,20 @@ function App() {
       let html;
       try {
         vtl = Velocity.render(debouncedContent, editionData);
-        console.log(html);
-        console.log("VTL OK");
+        // console.log(html);
+        // console.log("VTL OK");
       } catch (error) {
-        console.log("VTL ERROR");
-        console.log(error);
+        // console.log("VTL ERROR");
+        // console.log(error);
       }
       try {
         html = mjml2html(vtl).html;
         setRenderedContent(html);
-        console.log(html);
-        console.log("MJML OK");
+        // console.log(html);
+        // console.log("MJML OK");
       } catch (error) {
-        console.log("MJML ERROR");
-        console.log(error);
+        // console.log("MJML ERROR");
+        // console.log(error);
         return;
       }
     }
@@ -63,8 +60,8 @@ function App() {
       const json = JSON.parse(raw);
       setEditionData(json);
     } catch (error) {
-      console.log('DATA ERROR');
-      console.log(error);
+      // console.log('DATA ERROR');
+      // console.log(error);
     }
   };
 
@@ -126,14 +123,9 @@ function App() {
   const onCampaignFilenameChange = (event) => setCampaignFilename(event.target.value);
 
   const handleUseExampleJSON = () => {
-    // const json = JSON.parse(JSON.stringify(EXAMPLE_DATA, null, 4));
     const json = JSON.stringify(EXAMPLE_DATA, null, 4);
-    // const json = EXAMPLE_DATA;
-    console.log("before" + editionData);
     document.getElementById("dataTextarea").value = json;
-    // setEditionData(json);
     onDataChange(json);
-    console.log("after" + editionData);
   }
 
   return (

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,8 +56,7 @@ function App() {
 
   const onDataChange = (data) => {
     try {
-      const raw = data;
-      const json = JSON.parse(raw);
+      const json = JSON.parse(data);
       setEditionData(json);
     } catch (error) {
       // console.log('DATA ERROR');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,8 +13,8 @@ import useDebounce from "./useDebounce";
 import "./styles.css";
 
 const EXPORT_TYPE = {
-  MASTER: 'MASTER',
-  CAMPAIGN: 'CAMPAIGN',
+  ENCODED: 'ENCODED',
+  NOT_ENCODED: 'NOT ENCODED',
 }
 
 function App() {
@@ -22,7 +22,7 @@ function App() {
   const debouncedContent = useDebounce(rawContent, 500);
   const [renderedContent, setRenderedContent] = useState(null);
   const [editionData, setEditionData] = useState(null);
-  const [masterFilename, setMasterFilename] = useState("template");
+  // const [masterFilename, setMasterFilename] = useState("template");
   const [campaignFilename, setCampaignFilename] = useState("template");
 
   useEffect(() => {
@@ -117,7 +117,7 @@ function App() {
     }
   };
 
-  const onMasterFilenameChange = (event) => setMasterFilename(event.target.value);
+  // const onMasterFilenameChange = (event) => setMasterFilename(event.target.value);
   const onCampaignFilenameChange = (event) => setCampaignFilename(event.target.value);
 
   return (
@@ -140,17 +140,18 @@ function App() {
 
       <div className="section-titles">Data</div>
       <Data data={editionData} onChange={onDataChange} />
-      <Export
+      {/* Old Method which manually encodes the template, was used for when we didn't apply encoding on the backend */}
+      {/* <Export
         filename={masterFilename}
         onChange={onMasterFilenameChange}
         onExport={() => onExport(masterFilename, EXPORT_TYPE.MASTER)}
-        exportType={EXPORT_TYPE.MASTER}
-      />
+        exportType={EXPORT_TYPE.ENCODED}
+      /> */}
       <Export
         filename={campaignFilename}
         onChange={onCampaignFilenameChange}
         onExport={() => onExport(campaignFilename, EXPORT_TYPE.CAMPAIGN)}
-        exportType={EXPORT_TYPE.CAMPAIGN}
+        exportType={EXPORT_TYPE.NOT_ENCODED}
       />
     </>
   );

--- a/src/Data.jsx
+++ b/src/Data.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const Data = ({ data, onChange }) => (
   <div>
-    <textarea className="data" onChange={onChange}>
+    <textarea id="dataTextarea" className="data" onChange={onChange}>
       {data}
     </textarea>
   </div>

--- a/src/data/example.js
+++ b/src/data/example.js
@@ -1,0 +1,239 @@
+export const EXAMPLE_DATA = {
+  "sections": [
+    {
+      "sectionName": "Tech",
+      "sectionURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb91",
+      "showTitle": true,
+      "articles": [
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Tech Title 1: Title of the tech news",
+          "description": "Tech Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Tech Title 2: Second Tech Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Tech Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Tech Title 3: Third Tech Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Tech Description 3: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        }
+      ]
+    },
+    {
+      "sectionName": "Web",
+      "sectionURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb92",
+      "showTitle": true,
+      "articles": [
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Web Title 1: Title of the Web news",
+          "description": "Web Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Web Title 2: Second Web Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Web Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        }
+      ]
+    },
+    {
+      "sectionName": "Echobox",
+      "sectionURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb93",
+      "showTitle": true,
+      "articles": [
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Echobox Title 1: Title of the echobox news",
+          "description": "Echobox Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        }
+      ]
+    },
+    {
+      "sectionName": "Four Articles",
+      "sectionURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb93",
+      "showTitle": true,
+      "articles": [
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Echobox Title 1: Title of the echobox news",
+          "description": "Echobox Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        }
+      ]
+    },
+    {
+      "sectionName": "One Article",
+      "sectionURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb93",
+      "showTitle": true,
+      "articles": [
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "One Article Title 1: Title of the this article's news",
+          "description": "One Article Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        }
+      ]
+    },
+    {
+      "sectionName": "One Article With No Image",
+      "sectionURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb94",
+      "showTitle": false,
+      "articles": [
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Editorial Title 1: Title of the editorial news",
+          "description": "Editorial Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+          "imageURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Editorial No Image Title 1: Second Editorial Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Editorial No Image Description 1: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": ""
+        }
+      ]
+    },
+    {
+      "sectionName": "Two Articles With No Image",
+      "sectionURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb94",
+      "showTitle": false,
+      "articles": [
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Editorial No Image Title 1: Title of the editorial news",
+          "description": "Editorial Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+          "imageURL": ""
+        },
+        {
+          "articleURL": "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+          "title": "Editorial No Image Title 2: Second Editorial Article - Title of this news has more than 2 lines so the title will be truncated",
+          "description": "Editorial No Image Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+          "imageURL": ""
+        }
+      ]
+    }
+  ],
+"editorialNotes": [
+    {
+      "textBlockURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:editorialnote:b231a4da-9aef-4536-9845-33fe275aeb91",
+      "textBlockTitle": "Test Title - This is a test",
+      "editorialNoteString": "<p>This is a test</p><p>Test Link : <a href='https://www.google.com/' target='_blank'>Google</a>&nbsp;</p></div>"
+    },
+    {
+      "textBlockURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:editorialnote:b231a4da-9aef-4536-9845-33fe275aeb92",
+      "textBlockTitle": "",
+      "editorialNoteString": "<p>This is a test</p><p>Test Link : <a href='https://www.google.com/' target='_blank'>Google</a>&nbsp;</p></div>"
+    },
+    {
+      "textBlockURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:editorialnote:b231a4da-9aef-4536-9845-33fe275aeb93",
+      "textBlockTitle": "Test Title",
+      "editorialNoteString": ""
+    },
+    {
+      "textBlockURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:editorialnote:b231a4da-9aef-4536-9845-33fe275aeb94",
+      "textBlockTitle": "Test Title",
+      "editorialNoteString": "<p>This is a test</p>"
+    }
+    
+],
+"promotionBlocks": [
+    {
+      "promotionBlockURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb91",
+      "imageURL": "https://i.imgur.com/z8JR4i1.png",
+      "destinationURL": "https://www.newyorker.com/",
+      "bodyPosition": 1
+    },
+    {
+      "promotionBlockURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb92",
+      "imageURL": "https://www.coolmilk.com/wp-content/uploads/250-newsletter-banner-advert.png",
+      "destinationURL": "https://www.coolmilk.com/",
+      "bodyPosition": 3
+    },
+    {
+      "promotionBlockURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb93",
+      "imageURL": "https://thedirect.s3.amazonaws.com/media/photos/mandos2p1.jpg",
+      "destinationURL": "https://disneyplusoriginals.disney.com/show/the-mandalorian",
+      "bodyPosition": 5
+    }
+],
+"bodyElementPositioning": [
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:editorialnote:b231a4da-9aef-4536-9845-33fe275aeb91"},
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb91"},
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb91"},
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb92"},
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:editorialnote:b231a4da-9aef-4536-9845-33fe275aeb92"},
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb93"},
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:editorialnote:b231a4da-9aef-4536-9845-33fe275aeb93"},
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb93"},
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:editorialnote:b231a4da-9aef-4536-9845-33fe275aeb94"},
+  { "elementURN": "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb94"}
+],
+"campaignName": "CAMPAIGN'S NAME",
+"campaignGUID": "4bb4f503-abfe-446c-aa7e-e203f66196e2",
+"propertyName": "PUBLISHER NAME",
+"privacyPolicy": "https://www.PUBLISHER_NAME.com/privacy-policy",
+"footerText": "Copyright 2021 &copy; PUBLISHER_NAME <p>Check us out here : <a href='https://www.echobox.com/' target='_blank'>Echobox</a>&nbsp;</p>",
+"addressLine1": "Echobox",
+"addressLine2": "107 Cheapside",
+"city": "London",
+"postcode": "EC2V 6DN",
+"country": "United Kingdom",
+"phoneNumber": "+44-0-1179231245",
+"socialLinks":
+  {
+  "facebook": "PUBLISHER_NAME",
+  "twitter": "PUBLISHER_NAME",
+  "linkedin": "PUBLISHER_NAME",
+  "instagram": "PUBLISHER_NAME"
+  },
+"accentColour": "08678f",
+"bodyFont": "Open Sans",
+"titleFont": "Aclonica",
+"headerImageURL": "https://www.echobox.com/img/echobox.png",
+"headerLinkURL": "",
+"logoImageURL": "https://media-exp1.licdn.com/dms/image/C4E0BAQFOy-F-7DA_MA/company-logo_200_200/0/1567693261233?e=2159024400&v=beta&t=bsNthHvLmSsAxAaZw-6lUuhP2h50Kbdn-cpuMjD9rCQ",
+"callToActionText" : "See More Here",
+"socialNetworkLinkText": "Follow {propertyName} on:",
+"unsubscribeLinkText": "Stop following this newsletter?",
+"privacyPolicyLinkText": "Our Privacy Policy",
+"unsubscribeURL": "https://www.echobox.com/unsubscribe"
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,6 +15,7 @@ code {
 }
 
 .section-titles {
+  align-items: center;
   border-top: 1px solid #333;
   border-left: 1px solid #333;
   border-right: 1px solid #333;
@@ -27,6 +28,10 @@ code {
 
 .editor-container {
   width: 50%;
+}
+
+.editor-container section {
+  height: auto !important;
 }
 
 .editor {


### PR DESCRIPTION
## [TEC-14892](https://echobox.atlassian.net/browse/TEC-14892)

### Priority
Normal

### Description of Changes
- Commented out redundant export option (decided not to remove just in case you guys need to bring back encoding of templates on the conversion side of things).
- Added example json button which makes it much quicker to test templates rather than going between vscode and the converter multiple times.

### Testing
Ran locally and tested the conversion process.

### Deployment Considerations
- I will update the docs to mention the use of this example JSON button.
