### PR TITLE
NL-5308 Modify editor to accomodate for two inflation stages

### DIFF
--- a/src/Data.jsx
+++ b/src/Data.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 
-const Data = ({ data, onChange }) => (
+const Data = ({ data, index, onChange }) => (
   <div>
-    <textarea id="dataTextarea" className="data" onChange={onChange}>
+    <textarea id={`dataTextArea-${index}`} className="data" onChange={onChange}>
       {data}
     </textarea>
   </div>

--- a/src/data/articleDataExample.js
+++ b/src/data/articleDataExample.js
@@ -1,0 +1,131 @@
+export const EXAMPLE_ARTICLE_DATA = {
+  articleShareURL1:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle1: "Tech Title 1: Title of the tech news",
+  articleDescription1:
+    "Tech Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+  articleImageURL1:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL2:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle2:
+    "Tech Title 2: Second Tech Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription2:
+    "Tech Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL2:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL3:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle3:
+    "Tech Title 3: Third Tech Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription3:
+    "Tech Description 3: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL3:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL4:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle4: "Web Title 1: Title of the Web news",
+  articleDescription4:
+    "Web Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+  articleImageURL4:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL5:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle5:
+    "Web Title 2: Second Web Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription5:
+    "Web Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL5:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL6:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle6: "Echobox Title 1: Title of the echobox news",
+  articleDescription6:
+    "Echobox Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+  articleImageURL6:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL7:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle7:
+    "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription7:
+    "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL7:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL8:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle8:
+    "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription8:
+    "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL8:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL9:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle9: "Echobox Title 1: Title of the echobox news",
+  articleDescription9:
+    "Echobox Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+  articleImageURL9:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL10:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle10:
+    "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription10:
+    "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL10:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL11:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle11:
+    "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription11:
+    "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL11:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL12:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle12:
+    "Echobox Title 2: Second Echobox Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription12:
+    "Echobox Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL12:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL13:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle13: "One Article Title 1: Title of the this article's news",
+  articleDescription13:
+    "One Article Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+  articleImageURL13:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL14:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle14: "Editorial Title 1: Title of the editorial news",
+  articleDescription14:
+    "Editorial Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+  articleImageURL14:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleShareURL15:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle15:
+    "Editorial No Image Title 1: Second Editorial Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription15:
+    "Editorial No Image Description 1: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL15: "",
+  articleShareURL16:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle16: "Editorial No Image Title 1: Title of the editorial news",
+  articleDescription16:
+    "Editorial No Image Description 1: This text does not have a limit of lines because the amount of lines won't interfere in the Template Design. The spacing between the text and the next element is 40 pixels. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book...",
+  articleImageURL16: "",
+  articleShareURL17:
+    "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0",
+  articleTitle17:
+    "Editorial No Image Title 2: Second Editorial Article - Title of this news has more than 2 lines so the title will be truncated",
+  articleDescription17:
+    "Editorial No Image Description 2: Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC..",
+  articleImageURL17: "",
+  first_name: "John",
+  last_name: "Doe",
+  email_address: "john@doe.com"
+};

--- a/src/data/editionDataExample.js
+++ b/src/data/editionDataExample.js
@@ -1,0 +1,337 @@
+export const EXAMPLE_EDITION_DATA = {
+  emailPreviewText: "This is the email preview text",
+  sections: [
+    {
+      sectionName: "Tech",
+      sectionURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb91",
+      showTitle: true,
+      sectionType: "ARTICLES_SPONSORED",
+      articles: [
+        {
+          articleURL: "$articleShareURL1",
+          title: "$articleTitle1",
+          description: "$articleDescription1",
+          imageURL: "$articleImageURL1"
+        },
+        {
+          articleURL: "$articleShareURL2",
+          title: "$articleTitle2",
+          description: "$articleDescription2",
+          imageURL: "$articleImageURL2"
+        },
+        {
+          articleURL: "$articleShareURL3",
+          title: "$articleTitle3",
+          description: "$articleDescription3",
+          imageURL: "$articleImageURL3"
+        }
+      ]
+    },
+    {
+      sectionName: "Web",
+      sectionURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb92",
+      showTitle: true,
+      articles: [
+        {
+          articleURL: "$articleShareURL4",
+          title: "$articleTitle4",
+          description: "$articleDescription4",
+          imageURL: "$articleImageURL4"
+        },
+        {
+          articleURL: "$articleShareURL5",
+          title: "$articleTitle5",
+          description: "$articleDescription5",
+          imageURL: "$articleImageURL5"
+        }
+      ]
+    },
+    {
+      sectionName: "Echobox",
+      sectionURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb93",
+      showTitle: true,
+      articles: [
+        {
+          articleURL: "$articleShareURL6",
+          title: "$articleTitle6",
+          description: "$articleDescription6",
+          imageURL: "$articleImageURL6"
+        },
+        {
+          articleURL: "$articleShareURL7",
+          title: "$articleTitle7",
+          description: "$articleDescription7",
+          imageURL: "$articleImageURL7"
+        },
+        {
+          articleURL: "$articleShareURL8",
+          title: "$articleTitle8",
+          description: "$articleDescription8",
+          imageURL: "$articleImageURL8"
+        }
+      ]
+    },
+    {
+      sectionName: "Four Articles",
+      sectionURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb93",
+      showTitle: true,
+      sectionType: "ARTICLES_SPONSORED",
+      articles: [
+        {
+          articleURL: "$articleShareURL9",
+          title: "$articleTitle9",
+          description: "$articleDescription9",
+          imageURL: "$articleImageURL9"
+        },
+        {
+          articleURL: "$articleShareURL10",
+          title: "$articleTitle10",
+          description: "$articleDescription10",
+          imageURL: "$articleImageURL10"
+        },
+        {
+          articleURL: "$articleShareURL11",
+          title: "$articleTitle11",
+          description: "$articleDescription11",
+          imageURL: "$articleImageURL11"
+        },
+        {
+          articleURL: "$articleShareURL12",
+          title: "$articleTitle12",
+          description: "$articleDescription12",
+          imageURL: "$articleImageURL12"
+        }
+      ]
+    },
+    {
+      sectionName: "One Article",
+      sectionURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb93",
+      showTitle: true,
+      articles: [
+        {
+          articleURL: "$articleShareURL13",
+          title: "$articleTitle13",
+          description: "$articleDescription13",
+          imageURL: "$articleImageURL13"
+        }
+      ]
+    },
+    {
+      sectionName: "One Article With No Image",
+      sectionURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb94",
+      showTitle: false,
+      articles: [
+        {
+          articleURL: "$articleShareURL14",
+          title: "$articleTitle14",
+          description: "$articleDescription14",
+          imageURL: "$articleImageURL14"
+        },
+        {
+          articleURL: "$articleShareURL15",
+          title: "$articleTitle15",
+          description: "$articleDescription15",
+          imageURL: "$articleImageURL15"
+        }
+      ]
+    },
+    {
+      sectionName: "Two Articles With No Image",
+      sectionURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb94",
+      showTitle: false,
+      articles: [
+        {
+          articleURL: "$articleShareURL16",
+          title: "$articleTitle16",
+          description: "$articleDescription16",
+          imageURL: "$articleImageURL16"
+        },
+        {
+          articleURL: "$articleShareURL17",
+          title: "$articleTitle17",
+          description: "$articleDescription17",
+          imageURL: "$articleImageURL17"
+        }
+      ]
+    }
+  ],
+  textBlocks: [
+    {
+      textBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb91",
+      textBlockTitle: "Test Title - This is a test",
+      textBlockBody:
+        "<p>This is a test</p><p>Test Link : <a href='https://www.google.com/' target='_blank'>Google</a>&nbsp;</p></div>",
+      imageURL:
+        "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+    },
+    {
+      textBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb92",
+      textBlockTitle: "",
+      textBlockBody:
+        "<p>This is a test</p><p>Test Link : <a href='https://www.google.com/' target='_blank'>Google</a>&nbsp;</p></div>",
+      imageURL: ""
+    },
+    {
+      textBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb93",
+      textBlockTitle: "Test Title",
+      textBlockBody: "",
+      imageURL: ""
+    },
+    {
+      textBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb94",
+      textBlockTitle: "Test Title",
+      textBlockBody: "<p>This is a test</p>",
+      imageURL: ""
+    },
+    {
+      textBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb95",
+      textBlockTitle: "Test Title",
+      textBlockBody: "",
+      imageURL:
+        "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+    },
+    {
+      textBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb96",
+      textBlockTitle: "",
+      textBlockBody: "This is a test",
+      imageURL:
+        "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+    },
+    {
+      textBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb97",
+      textBlockTitle: "",
+      textBlockBody: "",
+      imageURL:
+        "https://i.guim.co.uk/img/media/cac17663240b12e92e6b9bf16e3ccf03459967ab/488_410_2101_1261/master/2101.jpg?width=1020&quality=85&auto=format&fit=max&s=8d38eb42a73baf5190a55f4ac1276bf0"
+    }
+  ],
+  promotionBlocks: [
+    {
+      promotionBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb91",
+      imageURL: "https://i.imgur.com/z8JR4i1.png",
+      destinationURL: "https://www.newyorker.com/",
+      bodyPosition: 1
+    },
+    {
+      promotionBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb92",
+      imageURL:
+        "https://www.coolmilk.com/wp-content/uploads/250-newsletter-banner-advert.png",
+      destinationURL: "https://www.coolmilk.com/",
+      bodyPosition: 3
+    },
+    {
+      promotionBlockURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb93",
+      imageURL: "https://thedirect.s3.amazonaws.com/media/photos/mandos2p1.jpg",
+      destinationURL:
+        "https://disneyplusoriginals.disney.com/show/the-mandalorian",
+      bodyPosition: 5
+    }
+  ],
+  bodyElementPositioning: [
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb91"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb91"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb91"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb92"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb92"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb93"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb93"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:promotionblock:c231a4da-9aef-4536-9845-33fe275aeb93"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb94"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:section:a231a4da-9aef-4536-9845-33fe275aeb94"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb95"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb96"
+    },
+    {
+      elementURN:
+        "urn:newsletter:campaign:d59028ac-9019-4c1a-b787-9e5fc80f9666:textblock:b231a4da-9aef-4536-9845-33fe275aeb97"
+    }
+  ],
+  campaignName: "CAMPAIGN'S NAME",
+  campaignGUID: "4bb4f503-abfe-446c-aa7e-e203f66196e2",
+  propertyName: "PUBLISHER NAME",
+  privacyPolicy: "https://www.PUBLISHER_NAME.com/privacy-policy",
+  footerText:
+    "Copyright 2021 &copy; PUBLISHER_NAME <p>Check us out here : <a href='https://www.echobox.com/' target='_blank'>Echobox</a>&nbsp;</p>",
+  addressLine1: "Echobox",
+  addressLine2: "107 Cheapside",
+  city: "London",
+  postcode: "EC2V 6DN",
+  country: "United Kingdom",
+  phoneNumber: "+44-0-1179231245",
+  socialLinks: {
+    facebook: "FACEBOOK_PAGE",
+    twitter: "TWITTER_PAGE",
+    linkedin: "LINKEDIN_PAGE",
+    instagram: "INSTAGRAM_PAGE",
+    youtube: "YOUTUBE_PAGE",
+    pinterest: "PINTEREST_PAGE",
+    tiktok: "TIKTOK_PAGE"
+  },
+  accentColour: "08678f",
+  bodyFont: "Open Sans",
+  titleFont: "Aclonica",
+  headerImageURL: "https://www.echobox.com/img/echobox.png",
+  headerLinkURL: "",
+  logoImageURL:
+    "https://media-exp1.licdn.com/dms/image/C4E0BAQFOy-F-7DA_MA/company-logo_200_200/0/1567693261233?e=2159024400&v=beta&t=bsNthHvLmSsAxAaZw-6lUuhP2h50Kbdn-cpuMjD9rCQ",
+  callToActionText: "See More Here",
+  socialNetworkLinkText: "Follow {propertyName} on:",
+  unsubscribeLinkText: "Stop following this newsletter?",
+  privacyPolicyLinkText: "Our Privacy Policy",
+  unsubscribeURL: "https://www.echobox.com/unsubscribe",
+  sponsoredContentLabel: "Sponsored",
+  manageYourPreferencesLinkText: "Manage your preferences",
+  manageYourPreferencesURL: "https://www.echobox.com/manage"
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -57,7 +57,7 @@ code {
 .data {
   border: 1px solid #333;
   width: calc(100% - 32px);
-  min-height: 10vh;
+  min-height: 5vh;
   margin: 0px 5px 5px 5px;
   padding: 10px;
   resize: vertical;


### PR DESCRIPTION
## [NL-5308](https://echobox.atlassian.net/browse/NL-5308)

### Spec 
N/A

### Priority
Normal

### Description of Changes
Editor has been modified to accomodate testing two inflation stages so we now have 2 input areas, one for edition data and branding but with placeholders for articles, and a second for article data and any personalisation data.
This mimics the process that happens when we inflate once and then send over a template for a second inflation.

Also made an additional change to escape any escaped (🤯) conditional velocity logic so it isn't lost when converting MJML to HTML.

Added some new example JSON files for the two data inputs as well.

Also updated e

### Documentation
N/A

### Risks & Impacts
Impacts template development process

### Security
N/A

### Testing
Made identical changes in this sandbox https://codesandbox.io/s/naughty-phoebe-k36g44?file=/src/App.jsx

### Deployment Considerations
None, any existing templates can still be tested with this new version