### PR TITLE
NL-10785 QA: Show correct file sizes in preview

### DIFF
--- a/src/Preview.jsx
+++ b/src/Preview.jsx
@@ -52,13 +52,13 @@ const Preview = ({ html }) => {
     return (
       html
         // Remove newlines
-        .replace(/\n/g, "")
+        .replace(/[\n\r]+/g, "")
         // Remove leading tabs and spaces
-        .replace(/[\t ]+\</g, "<")
+        .replace(/[\t ]+</g, "<")
         // Remove spaces between tags
-        .replace(/\>[\t ]+\</g, "><")
+        .replace(/>[\t ]+</g, "><")
         // Remove trailing tabs and spaces
-        .replace(/\>[\t ]+$/g, ">")
+        .replace(/>[\t ]+$/g, ">")
     );
   }
 


### PR DESCRIPTION
Correctly strip newlines in order to show the correct compressed file size